### PR TITLE
Ability for Compressed PositionPackets to be Generated

### DIFF
--- a/src/main/java/net/ab0oo/aprs/parser/Position.java
+++ b/src/main/java/net/ab0oo/aprs/parser/Position.java
@@ -35,6 +35,7 @@ public class Position implements java.io.Serializable {
 	private Integer positionAmbiguity;
 	private Date timestamp;
 	private char symbolTable, symbolCode;
+	private String csTField = " sT";
 
 	public Position() {
 	    timestamp = new Date();
@@ -193,7 +194,18 @@ public class Position implements java.io.Serializable {
 	public String toDecimalString() {
 		return latitude+", "+longitude;
 	}
-	
+
+	public void setCsTField(String val) {
+		if(val == null || val == "") {
+			val = " sT";
+		}
+		csTField = val;
+	}
+
+	public String getCsTField() {
+		return csTField;
+	}
+
 	public String toCompressedString() {
 		long latbase = Math.round(380926 * (90-this.latitude));
 		long latchar1 = latbase / (91*91*91)+33;
@@ -211,7 +223,7 @@ public class Position implements java.io.Serializable {
 		int lonchar4 = (int)(lonbase % 91)+33;
 		
 		return ""+symbolTable+(char)latchar1+(char)latchar2+(char)latchar3+(char)latchar4+
-				""+(char)lonchar1+(char)lonchar2+(char)lonchar3+(char)lonchar4+symbolCode+" sT";
+				""+(char)lonchar1+(char)lonchar2+(char)lonchar3+(char)lonchar4+symbolCode+csTField;
 	}
 
 	public static float distFrom(double lat1, double lng1, double lat2, double lng2) {

--- a/src/main/java/net/ab0oo/aprs/parser/PositionPacket.java
+++ b/src/main/java/net/ab0oo/aprs/parser/PositionPacket.java
@@ -28,6 +28,7 @@ public class PositionPacket extends InformationField implements java.io.Serializ
 	private static final long serialVersionUID = 1L;
 	private Position position;
 	private String positionSource;
+	private boolean compressedFormat;
 
 	public PositionPacket(byte[] msgBody, String destinationField)
 			throws Exception {
@@ -111,16 +112,26 @@ public class PositionPacket extends InformationField implements java.io.Serializ
 		if (cursor > 0 && cursor < msgBody.length) {
 			comment = new String(msgBody, cursor, msgBody.length - cursor, "UTF-8");
 		}
+		compressedFormat = false;
 	}
 	public PositionPacket(Position position, String comment) {
 		this.position = position;
 		this.type = APRSTypes.T_POSITION;
 		this.comment = comment;
+		compressedFormat = false;
 	}
 
 	public PositionPacket(Position position, String comment, boolean msgCapable) {
 		this(position, comment);
 		canMessage = msgCapable;
+	}
+
+	public void setCompressedFormat(boolean val) {
+		compressedFormat = val;
+	}
+
+	public boolean getCompressedFormat() {
+		return compressedFormat;
 	}
 
 	private boolean validSymTableCompressed(char c) {
@@ -161,8 +172,11 @@ public class PositionPacket extends InformationField implements java.io.Serializ
 	public String toString() {
 		if (rawBytes != null)
 			return new String(rawBytes);
+		if (compressedFormat)
+			return (canMessage ? "=" : "!") + position.toCompressedString() + comment;
 		return (canMessage ? "=" : "!") + position + comment;
 	}
+
 	/**
 	 * @return the positionSource
 	 */


### PR DESCRIPTION
Currently javAPRSlib cannot output compressed position packets, which is problematic for situations when APRSdroid or similar applications are transmitting using HF. Uncompressed location packets are generally frowned upon when used with APRS over HF