### PR TITLE
Callsign normalization and timestamp parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ jdk:
   - openjdk8
   - openjdk11
 
-script: ./mvnw test -B && ./mvnw package -B
+script: ./mvnw test -B && ./mvnw package -B && ant clean compile-library

--- a/build.xml
+++ b/build.xml
@@ -13,7 +13,7 @@
 			optimize="true"
 			debug="true" >
 
-			<src path="src/" />
+			<src path="src/main/" />
 			<include name="**/*.java" />
 
 		</javac>

--- a/src/main/java/net/ab0oo/aprs/parser/Callsign.java
+++ b/src/main/java/net/ab0oo/aprs/parser/Callsign.java
@@ -34,7 +34,7 @@ public class Callsign implements Serializable {
 
 	public Callsign(String call) {
 		String[] callssid = call.split("-");
-		this.callsign = callssid[0];
+		this.callsign = callssid[0].toUpperCase();
 		if (callssid.length > 1) {
 			this.ssid = callssid[1];
 		} else {

--- a/src/main/java/net/ab0oo/aprs/parser/Callsign.java
+++ b/src/main/java/net/ab0oo/aprs/parser/Callsign.java
@@ -65,7 +65,7 @@ public class Callsign implements Serializable {
      * @param callsign the callsign to set
      */
     public void setCallsign(String callsign) {
-        this.callsign = callsign;
+        this.callsign = callsign.toUpperCase();
     }
 
     /**

--- a/src/main/java/net/ab0oo/aprs/parser/PositionParser.java
+++ b/src/main/java/net/ab0oo/aprs/parser/PositionParser.java
@@ -24,6 +24,7 @@
  */
 package net.ab0oo.aprs.parser;
 
+import java.util.Date;
 import java.util.regex.Pattern;
 
 /**
@@ -37,8 +38,17 @@ public class PositionParser {
     public static Position parseUncompressed(byte[] msgBody, int cursor) throws Exception {
         // System.out.print("UN: ");
 
+        Date date = new Date();
         if (msgBody[0] == '/' || msgBody[0] == '@') {
             // With a prepended timestamp, jump over it.
+            if (msgBody[cursor+6] == 'z') {
+                int day    = (msgBody[cursor+0] - '0') * 10 + msgBody[cursor+1] - '0';
+                int hour   = (msgBody[cursor+2] - '0') * 10 + msgBody[cursor+3] - '0';
+                int minute = (msgBody[cursor+4] - '0') * 10 + msgBody[cursor+5] - '0';
+                date.setDate(day);
+                date.setHours(hour);
+                date.setMinutes(minute);
+            }
             cursor += 7;
         }
         if (msgBody.length < cursor + 19) {
@@ -119,7 +129,9 @@ public class PositionParser {
                 longitude = 0.0F - longitude;
             else if (lngh != 'e' && lngh != 'E')
                 throw new Exception("Bad longitude sign character");
-            return new Position(latitude, longitude, positionAmbiguity, symbolTable, symbolCode);
+            Position position = new Position(latitude, longitude, positionAmbiguity, symbolTable, symbolCode);
+            position.setTimestamp(date);
+            return position;
         } catch (Exception e) {
             throw new Exception(e);
         }

--- a/src/test/java/net/ab0oo/aprs/parser/APRSPacketTests.java
+++ b/src/test/java/net/ab0oo/aprs/parser/APRSPacketTests.java
@@ -2,13 +2,8 @@ package net.ab0oo.aprs.parser;
 
 import java.util.List;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import static org.junit.jupiter.api.Assertions.*;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.DisplayName;
@@ -16,14 +11,6 @@ import org.junit.jupiter.api.DisplayName;
 
 @DisplayName("APRS Packet Tests")
 public class APRSPacketTests {
-	@BeforeEach
-	public void setUp() {
-	}
-
-	@AfterEach
-	public void tearDown() {
-	}
-
 	@Nested
 	@DisplayName("Given an empty APRS packet")
 	public class GivenEmptyAPRSPacket {

--- a/src/test/java/net/ab0oo/aprs/parser/CallsignTest.java
+++ b/src/test/java/net/ab0oo/aprs/parser/CallsignTest.java
@@ -8,15 +8,18 @@ import org.junit.jupiter.api.DisplayName;
  
 
 @DisplayName("Callsign Tests")
-public class CallsignTest {
+class CallsignTest {
+	/* TODO Test SSID 0 */
+	/* TODO Test serialization */
+
 	@Nested
 	@DisplayName("Given regular APRS callsign with SSID")
-	public class GivenRegularCallsignSsid {
+	class GivenRegularCallsignSsid {
 		final String callsign = "AB1CDE-12";
 
 		@Nested
 		@DisplayName("When instantiated as a class")
-		public class WhenInstantiated {
+		class WhenInstantiated {
 			Callsign object;
 
 			@BeforeEach
@@ -26,19 +29,25 @@ public class CallsignTest {
 
 			@Test
 			@DisplayName("Then it should return the proper callsign")
-			public void thenReturnCallsign() {
+			void thenReturnCallsign() {
 				assertEquals("AB1CDE", object.getCallsign());
 			}
 
 			@Test
 			@DisplayName("Then it should return the proper SSID")
-			public void thenReturnSsid() {
+			void thenReturnSsid() {
 				assertEquals("12", object.getSsid());
 			}
 
 			@Test
+			@DisplayName("Then it should return the proper string")
+			void thenReturnProperString() {
+				assertEquals("AB1CDE-12", object.toString());
+			}
+
+			@Test
 			@DisplayName("Then it should return correct AX25 data")
-			public void thenReturnAX25() {
+			void thenReturnAX25() {
 				final byte[] expected = {
 					(byte)('A' << 1),
 					(byte)('B' << 1),
@@ -55,7 +64,7 @@ public class CallsignTest {
 
 		@Nested
 		@DisplayName("When converted to bytes and back")
-		public class WhenConverted {
+		class WhenConverted {
 			Callsign object;
 
 			@BeforeEach
@@ -66,19 +75,25 @@ public class CallsignTest {
 
 			@Test
 			@DisplayName("Then it should return the proper callsign")
-			public void thenReturnCallsign() {
+			void thenReturnCallsign() {
 				assertEquals("AB1CDE", object.getCallsign());
 			}
 
 			@Test
 			@DisplayName("Then it should return the proper SSID")
-			public void thenReturnSsid() {
+			void thenReturnSsid() {
 				assertEquals("12", object.getSsid());
 			}
 
 			@Test
+			@DisplayName("Then it should return the proper string")
+			void thenReturnProperString() {
+				assertEquals("AB1CDE-12", object.toString());
+			}
+
+			@Test
 			@DisplayName("Then it should return correct AX25 data")
-			public void thenReturnAX25() {
+			void thenReturnAX25() {
 				final byte[] expected = {
 					(byte)('A' << 1),
 					(byte)('B' << 1),
@@ -96,12 +111,12 @@ public class CallsignTest {
 
 	@Nested
 	@DisplayName("Given lowercase APRS callsign")
-	public class GivenLowercaseCallsign {
+	class GivenLowercaseCallsign {
 		final String callsign = "ab1cde";
 
 		@Nested
 		@DisplayName("When instantiated as a class")
-		public class WhenInstantiated {
+		class WhenInstantiated {
 			Callsign object;
 
 			@BeforeEach
@@ -111,19 +126,25 @@ public class CallsignTest {
 
 			@Test
 			@DisplayName("Then it should return the proper callsign")
-			public void thenReturnCallsign() {
+			void thenReturnCallsign() {
 				assertEquals("AB1CDE", object.getCallsign());
 			}
 
 			@Test
 			@DisplayName("Then it should return the proper SSID")
-			public void thenReturnSsid() {
+			void thenReturnSsid() {
 				assertEquals("", object.getSsid());
 			}
 
 			@Test
+			@DisplayName("Then it should return the proper string")
+			void thenReturnProperString() {
+				assertEquals("AB1CDE", object.toString());
+			}
+
+			@Test
 			@DisplayName("Then it should return correct AX25 data")
-			public void thenReturnAX25() {
+			void thenReturnAX25() {
 				final byte[] expected = {
 					(byte)('A' << 1),
 					(byte)('B' << 1),
@@ -140,7 +161,7 @@ public class CallsignTest {
 
 		@Nested
 		@DisplayName("When converted to bytes and back")
-		public class WhenConverted {
+		class WhenConverted {
 			Callsign object;
 
 			@BeforeEach
@@ -151,19 +172,25 @@ public class CallsignTest {
 
 			@Test
 			@DisplayName("Then it should return the proper callsign")
-			public void thenReturnCallsign() {
+			void thenReturnCallsign() {
 				assertEquals("AB1CDE", object.getCallsign());
 			}
 
 			@Test
 			@DisplayName("Then it should return the proper SSID")
-			public void thenReturnSsid() {
+			void thenReturnSsid() {
 				assertEquals("", object.getSsid());
 			}
 
 			@Test
+			@DisplayName("Then it should return the proper string")
+			void thenReturnProperString() {
+				assertEquals("AB1CDE", object.toString());
+			}
+
+			@Test
 			@DisplayName("Then it should return correct AX25 data")
-			public void thenReturnAX25() {
+			void thenReturnAX25() {
 				final byte[] expected = {
 					(byte)('A' << 1),
 					(byte)('B' << 1),
@@ -172,6 +199,146 @@ public class CallsignTest {
 					(byte)('D' << 1),
 					(byte)('E' << 1),
 					(byte)(0x60 | (0 << 1)),
+				};
+				assertEquals(7, object.toAX25().length);
+				assertArrayEquals(expected, object.toAX25());
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName("Given an APRS callsign")
+	class GivenCallsign {
+		Callsign object;
+
+		@BeforeEach
+		void setUp() {
+			object = new Callsign("W1AW-5");
+		}
+
+		@Nested
+		@DisplayName("When changing callsign")
+		class WhenCallsignChanged {
+			@BeforeEach
+			void setUp() {
+				object.setCallsign("NJ7P");
+			}
+
+			@Test
+			@DisplayName("Then it should return the new callsign")
+			void thenReturnNewCallsign() {
+				assertEquals("NJ7P", object.getCallsign());
+			}
+
+			@Test
+			@DisplayName("Then it should return the original SSID")
+			void thenReturnOriginalSsid() {
+				assertEquals("5", object.getSsid());
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper string")
+			void thenReturnProperString() {
+				assertEquals("NJ7P-5", object.toString());
+			}
+
+			@Test
+			@DisplayName("Then it should return correct AX25 data")
+			void thenReturnAX25() {
+				final byte[] expected = {
+					(byte)('N' << 1),
+					(byte)('J' << 1),
+					(byte)('7' << 1),
+					(byte)('P' << 1),
+					(byte)(' ' << 1),
+					(byte)(' ' << 1),
+					(byte)(0x60 | (5 << 1)),
+				};
+				assertEquals(7, object.toAX25().length);
+				assertArrayEquals(expected, object.toAX25());
+			}
+		}
+
+		@Nested
+		@DisplayName("When changing ssid")
+		class WhenSsidChanged {
+			@BeforeEach
+			void setUp() {
+				object.setSsid("9");
+			}
+
+			@Test
+			@DisplayName("Then it should return the original callsign")
+			void thenReturnOriginalCallsign() {
+				assertEquals("W1AW", object.getCallsign());
+			}
+
+			@Test
+			@DisplayName("Then it should return the new SSID")
+			void thenReturnNewSsid() {
+				assertEquals("9", object.getSsid());
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper string")
+			void thenReturnProperString() {
+				assertEquals("W1AW-9", object.toString());
+			}
+
+			@Test
+			@DisplayName("Then it should return correct AX25 data")
+			void thenReturnAX25() {
+				final byte[] expected = {
+					(byte)('W' << 1),
+					(byte)('1' << 1),
+					(byte)('A' << 1),
+					(byte)('W' << 1),
+					(byte)(' ' << 1),
+					(byte)(' ' << 1),
+					(byte)(0x60 | (9 << 1)),
+				};
+				assertEquals(7, object.toAX25().length);
+				assertArrayEquals(expected, object.toAX25());
+			}
+		}
+
+		@Nested
+		@DisplayName("When changing to mixed-case callsign")
+		class WhenCallsignChangedMixedCase {
+			@BeforeEach
+			void setUp() {
+				object.setCallsign("N7lEm");
+			}
+
+			@Test
+			@DisplayName("Then it should return the new uppercase callsign")
+			void thenReturnNewCallsign() {
+				assertEquals("N7LEM", object.getCallsign());
+			}
+
+			@Test
+			@DisplayName("Then it should return the original SSID")
+			void thenReturnOriginalSsid() {
+				assertEquals("5", object.getSsid());
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper string")
+			void thenReturnProperString() {
+				assertEquals("N7LEM-5", object.toString());
+			}
+
+			@Test
+			@DisplayName("Then it should return correct AX25 data")
+			void thenReturnAX25() {
+				final byte[] expected = {
+					(byte)('N' << 1),
+					(byte)('7' << 1),
+					(byte)('L' << 1),
+					(byte)('E' << 1),
+					(byte)('M' << 1),
+					(byte)(' ' << 1),
+					(byte)(0x60 | (5 << 1)),
 				};
 				assertEquals(7, object.toAX25().length);
 				assertArrayEquals(expected, object.toAX25());

--- a/src/test/java/net/ab0oo/aprs/parser/CallsignTest.java
+++ b/src/test/java/net/ab0oo/aprs/parser/CallsignTest.java
@@ -2,7 +2,6 @@ package net.ab0oo.aprs.parser;
 
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.DisplayName;
@@ -100,7 +99,6 @@ public class CallsignTest {
 	public class GivenLowercaseCallsign {
 		final String callsign = "ab1cde";
 
-		@Disabled
 		@Nested
 		@DisplayName("When instantiated as a class")
 		public class WhenInstantiated {
@@ -151,7 +149,6 @@ public class CallsignTest {
 					new Callsign(callsign).toAX25(), 0);
 			}
 
-			@Disabled
 			@Test
 			@DisplayName("Then it should return the proper callsign")
 			public void thenReturnCallsign() {
@@ -164,7 +161,6 @@ public class CallsignTest {
 				assertEquals("", object.getSsid());
 			}
 
-			@Disabled
 			@Test
 			@DisplayName("Then it should return correct AX25 data")
 			public void thenReturnAX25() {

--- a/src/test/java/net/ab0oo/aprs/parser/CallsignTest.java
+++ b/src/test/java/net/ab0oo/aprs/parser/CallsignTest.java
@@ -1,0 +1,185 @@
+package net.ab0oo.aprs.parser;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.DisplayName;
+ 
+
+@DisplayName("Callsign Tests")
+public class CallsignTest {
+	@Nested
+	@DisplayName("Given regular APRS callsign with SSID")
+	public class GivenRegularCallsignSsid {
+		final String callsign = "AB1CDE-12";
+
+		@Nested
+		@DisplayName("When instantiated as a class")
+		public class WhenInstantiated {
+			Callsign object;
+
+			@BeforeEach
+			void setUp() {
+				object = new Callsign(callsign);
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper callsign")
+			public void thenReturnCallsign() {
+				assertEquals("AB1CDE", object.getCallsign());
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper SSID")
+			public void thenReturnSsid() {
+				assertEquals("12", object.getSsid());
+			}
+
+			@Test
+			@DisplayName("Then it should return correct AX25 data")
+			public void thenReturnAX25() {
+				final byte[] expected = {
+					(byte)('A' << 1),
+					(byte)('B' << 1),
+					(byte)('1' << 1),
+					(byte)('C' << 1),
+					(byte)('D' << 1),
+					(byte)('E' << 1),
+					(byte)(0x60 | (12 << 1)),
+				};
+				assertEquals(7, object.toAX25().length);
+				assertArrayEquals(expected, object.toAX25());
+			}
+		}
+
+		@Nested
+		@DisplayName("When converted to bytes and back")
+		public class WhenConverted {
+			Callsign object;
+
+			@BeforeEach
+			void setUp() {
+				object = new Callsign(
+					new Callsign(callsign).toAX25(), 0);
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper callsign")
+			public void thenReturnCallsign() {
+				assertEquals("AB1CDE", object.getCallsign());
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper SSID")
+			public void thenReturnSsid() {
+				assertEquals("12", object.getSsid());
+			}
+
+			@Test
+			@DisplayName("Then it should return correct AX25 data")
+			public void thenReturnAX25() {
+				final byte[] expected = {
+					(byte)('A' << 1),
+					(byte)('B' << 1),
+					(byte)('1' << 1),
+					(byte)('C' << 1),
+					(byte)('D' << 1),
+					(byte)('E' << 1),
+					(byte)(0x60 | (12 << 1)),
+				};
+				assertEquals(7, object.toAX25().length);
+				assertArrayEquals(expected, object.toAX25());
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName("Given lowercase APRS callsign")
+	public class GivenLowercaseCallsign {
+		final String callsign = "ab1cde";
+
+		@Disabled
+		@Nested
+		@DisplayName("When instantiated as a class")
+		public class WhenInstantiated {
+			Callsign object;
+
+			@BeforeEach
+			void setUp() {
+				object = new Callsign(callsign);
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper callsign")
+			public void thenReturnCallsign() {
+				assertEquals("AB1CDE", object.getCallsign());
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper SSID")
+			public void thenReturnSsid() {
+				assertEquals("", object.getSsid());
+			}
+
+			@Test
+			@DisplayName("Then it should return correct AX25 data")
+			public void thenReturnAX25() {
+				final byte[] expected = {
+					(byte)('A' << 1),
+					(byte)('B' << 1),
+					(byte)('1' << 1),
+					(byte)('C' << 1),
+					(byte)('D' << 1),
+					(byte)('E' << 1),
+					(byte)(0x60 | (0 << 1)),
+				};
+				assertEquals(7, object.toAX25().length);
+				assertArrayEquals(expected, object.toAX25());
+			}
+		}
+
+		@Nested
+		@DisplayName("When converted to bytes and back")
+		public class WhenConverted {
+			Callsign object;
+
+			@BeforeEach
+			void setUp() {
+				object = new Callsign(
+					new Callsign(callsign).toAX25(), 0);
+			}
+
+			@Disabled
+			@Test
+			@DisplayName("Then it should return the proper callsign")
+			public void thenReturnCallsign() {
+				assertEquals("AB1CDE", object.getCallsign());
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper SSID")
+			public void thenReturnSsid() {
+				assertEquals("", object.getSsid());
+			}
+
+			@Disabled
+			@Test
+			@DisplayName("Then it should return correct AX25 data")
+			public void thenReturnAX25() {
+				final byte[] expected = {
+					(byte)('A' << 1),
+					(byte)('B' << 1),
+					(byte)('1' << 1),
+					(byte)('C' << 1),
+					(byte)('D' << 1),
+					(byte)('E' << 1),
+					(byte)(0x60 | (0 << 1)),
+				};
+				assertEquals(7, object.toAX25().length);
+				assertArrayEquals(expected, object.toAX25());
+			}
+		}
+	}
+}

--- a/src/test/java/net/ab0oo/aprs/parser/DigipeaterTest.java
+++ b/src/test/java/net/ab0oo/aprs/parser/DigipeaterTest.java
@@ -1,0 +1,291 @@
+package net.ab0oo.aprs.parser;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.DisplayName;
+ 
+
+@DisplayName("Digipeater Tests")
+class DigipeaterTest {
+	/* TODO Test serialization */
+	/* TODO Fix code duplication */
+
+	@Nested
+	@DisplayName("Given unused, mixed-case APRS digipeater with SSID")
+	class GivenUnuseddDigipeaterSsid {
+		final String digipeater = "W1aw-15";
+
+		@Nested
+		@DisplayName("When instantiated as a class")
+		class WhenInstantiated {
+			Digipeater object;
+
+			@BeforeEach
+			void setUp() {
+				object = new Digipeater(digipeater);
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper callsign")
+			void thenReturnCallsign() {
+				assertEquals("W1AW", object.getCallsign());
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper SSID")
+			void thenReturnSsid() {
+				assertEquals("15", object.getSsid());
+			}
+
+			@Test
+			@DisplayName("Then it should return as unused")
+			void thenReturnUsed() {
+				assertFalse(object.isUsed(), "Should not be used");
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper string")
+			void thenReturnProperString() {
+				assertEquals("W1AW-15", object.toString());
+			}
+
+			@Test
+			@DisplayName("Then it should return correct AX25 data")
+			void thenReturnAX25() {
+				final byte[] expected = {
+					(byte)('W' << 1),
+					(byte)('1' << 1),
+					(byte)('A' << 1),
+					(byte)('W' << 1),
+					(byte)(' ' << 1),
+					(byte)(' ' << 1),
+					(byte)(0*0x80 | 0x60 | (15 << 1)),
+				};
+				assertEquals(7, object.toAX25().length);
+				assertArrayEquals(expected, object.toAX25());
+			}
+		}
+
+		@Nested
+		@DisplayName("When converted to bytes and back")
+		class WhenConverted {
+			Digipeater object;
+
+			@BeforeEach
+			void setUp() {
+				object = new Digipeater(
+					new Digipeater(digipeater).toAX25(), 0);
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper callsign")
+			void thenReturnCallsign() {
+				assertEquals("W1AW", object.getCallsign());
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper SSID")
+			void thenReturnSsid() {
+				assertEquals("15", object.getSsid());
+			}
+
+			@Test
+			@DisplayName("Then it should return as unused")
+			void thenReturnUsed() {
+				assertFalse(object.isUsed(), "Should not be used");
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper string")
+			void thenReturnProperString() {
+				assertEquals("W1AW-15", object.toString());
+			}
+
+			@Test
+			@DisplayName("Then it should return correct AX25 data")
+			void thenReturnAX25() {
+				final byte[] expected = {
+					(byte)('W' << 1),
+					(byte)('1' << 1),
+					(byte)('A' << 1),
+					(byte)('W' << 1),
+					(byte)(' ' << 1),
+					(byte)(' ' << 1),
+					(byte)(0*0x80 | 0x60 | (15 << 1)),
+				};
+				assertEquals(7, object.toAX25().length);
+				assertArrayEquals(expected, object.toAX25());
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName("Given used, lower-case APRS digipeater")
+	class GivenUsedLowercaseDigipeater {
+		final String digipeater = "ab1cde*";
+
+		@Nested
+		@DisplayName("When instantiated as a class")
+		class WhenInstantiated {
+			Digipeater object;
+
+			@BeforeEach
+			void setUp() {
+				object = new Digipeater(digipeater);
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper callsign")
+			void thenReturnCallsign() {
+				assertEquals("AB1CDE", object.getCallsign());
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper SSID")
+			void thenReturnSsid() {
+				assertEquals("", object.getSsid());
+			}
+
+			@Test
+			@DisplayName("Then it should return as used")
+			void thenReturnUsed() {
+				assertTrue(object.isUsed(), "Should be used");
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper string")
+			void thenReturnProperString() {
+				assertEquals("AB1CDE*", object.toString());
+			}
+
+			@Test
+			@DisplayName("Then it should return correct AX25 data")
+			void thenReturnAX25() {
+				final byte[] expected = {
+					(byte)('A' << 1),
+					(byte)('B' << 1),
+					(byte)('1' << 1),
+					(byte)('C' << 1),
+					(byte)('D' << 1),
+					(byte)('E' << 1),
+					(byte)(1*0x80 | 0x60 | (0 << 1)),
+				};
+				assertEquals(7, object.toAX25().length);
+				assertArrayEquals(expected, object.toAX25());
+			}
+		}
+
+		@Nested
+		@DisplayName("When converted to bytes and back")
+		class WhenConverted {
+			Digipeater object;
+
+			@BeforeEach
+			void setUp() {
+				object = new Digipeater(
+					new Digipeater(digipeater).toAX25(), 0);
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper callsign")
+			void thenReturnCallsign() {
+				assertEquals("AB1CDE", object.getCallsign());
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper SSID")
+			void thenReturnSsid() {
+				assertEquals("", object.getSsid());
+			}
+
+			@Test
+			@DisplayName("Then it should return as used")
+			void thenReturnUsed() {
+				assertTrue(object.isUsed(), "Should be used");
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper string")
+			void thenReturnProperString() {
+				assertEquals("AB1CDE*", object.toString());
+			}
+
+			@Test
+			@DisplayName("Then it should return correct AX25 data")
+			void thenReturnAX25() {
+				final byte[] expected = {
+					(byte)('A' << 1),
+					(byte)('B' << 1),
+					(byte)('1' << 1),
+					(byte)('C' << 1),
+					(byte)('D' << 1),
+					(byte)('E' << 1),
+					(byte)(1*0x80 | 0x60 | (0 << 1)),
+				};
+				assertEquals(7, object.toAX25().length);
+				assertArrayEquals(expected, object.toAX25());
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName("Given an APRS digipeater")
+	class GivenDigipeater {
+		Digipeater object;
+
+		@BeforeEach
+		void setUp() {
+			object = new Digipeater("W1AW-1");
+		}
+		@Nested
+		@DisplayName("When changing ssid")
+		class WhenUsedChanged {
+			@BeforeEach
+			void setUp() {
+				object.setUsed(true);
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper callsign")
+			void thenReturnCallsign() {
+				assertEquals("W1AW", object.getCallsign());
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper SSID")
+			void thenReturnNewSsid() {
+				assertEquals("1", object.getSsid());
+			}
+
+			@Test
+			@DisplayName("Then it should return as used")
+			void thenReturnUsed() {
+				assertTrue(object.isUsed(), "Should be used");
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper string")
+			void thenReturnProperString() {
+				assertEquals("W1AW-1*", object.toString());
+			}
+
+			@Test
+			@DisplayName("Then it should return correct AX25 data")
+			void thenReturnAX25() {
+				final byte[] expected = {
+					(byte)('W' << 1),
+					(byte)('1' << 1),
+					(byte)('A' << 1),
+					(byte)('W' << 1),
+					(byte)(' ' << 1),
+					(byte)(' ' << 1),
+					(byte)(1*0x80 | 0x60 | (1 << 1)),
+				};
+				assertEquals(7, object.toAX25().length);
+				assertArrayEquals(expected, object.toAX25());
+			}
+		}
+	}
+}

--- a/src/test/java/net/ab0oo/aprs/parser/PositionPacketTest.java
+++ b/src/test/java/net/ab0oo/aprs/parser/PositionPacketTest.java
@@ -61,7 +61,6 @@ class PositionPacketTest {
 				assertEquals(0, pos.getPositionAmbiguity());
 			}
 
-			@Disabled("Time is being returned in local time, is this correct?")
 			@Test
 			@DisplayName("Then it should return the proper timestamp")
 			void thenReturnTimestamp() {

--- a/src/test/java/net/ab0oo/aprs/parser/PositionPacketTest.java
+++ b/src/test/java/net/ab0oo/aprs/parser/PositionPacketTest.java
@@ -1,0 +1,312 @@
+package net.ab0oo.aprs.parser;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.DisplayName;
+ 
+
+@DisplayName("Position Packet Tests")
+class PositionPacketTest {
+	/* TODO Test serialization */
+	/* TODO Fix code duplication */
+
+	@Nested
+	@DisplayName("Given a valid APRS location message body")
+	class GivenValidAPRSLocationMessage {
+		final String body = "@120845z3111.02NI08122.52W&V=12.3";
+
+		@Nested
+		@DisplayName("When parsed as a packet")
+		class WhenParsed {
+			PositionPacket packet;
+
+			@BeforeEach
+			void setUp() {
+				try {
+					packet = new PositionPacket(body.getBytes(), null);
+				} catch(Exception ex) {
+					packet = null;
+				}
+			}
+
+			@Test
+			@DisplayName("Then it should not have raised an exception")
+			void thenReturnValid() {
+				assertNotNull(packet, "Exception raised during packet parsing");
+			}
+
+			@Test
+			@DisplayName("Then it should not be compressed")
+			void thenReturnUncompressed() {
+				assertFalse(packet.getCompressedFormat());
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper position sourcce")
+			void thenReturnSource() {
+				assertEquals("Uncompressed", packet.getPositionSource());
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper location")
+			void thenReturnLocation() {
+				Position pos = packet.getPosition();
+				assertEquals( (31. + 11.02/60.), pos.getLatitude(),  0.001);
+				assertEquals(-(81. + 22.52/60.), pos.getLongitude(), 0.001);
+				assertEquals(0, pos.getPositionAmbiguity());
+			}
+
+			@Disabled("Time is being returned in local time, is this correct?")
+			@Test
+			@DisplayName("Then it should return the proper timestamp")
+			void thenReturnTimestamp() {
+				Position pos = packet.getPosition();
+				Date time = pos.getTimestamp();
+				assertEquals(12, time.getDate());
+				assertEquals(8, time.getHours());
+				assertEquals(45, time.getMinutes());
+			}
+
+			@Test
+			@DisplayName("Then it should return the original raw bytes")
+			void thenReturnRawBytes() {
+				assertArrayEquals(body.getBytes(), packet.getRawBytes());
+			}
+
+			@Test
+			@DisplayName("Then it should return the original string")
+			void thenReturnString() {
+				assertEquals(body, packet.toString());
+			}
+		}
+
+		/*
+		@Nested
+		@DisplayName("When converted to bytes and back")
+		class WhenConverted {
+			Digipeater object;
+
+			@BeforeEach
+			void setUp() {
+				object = new Digipeater(
+					new Digipeater(digipeater).toAX25(), 0);
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper callsign")
+			void thenReturnCallsign() {
+				assertEquals("W1AW", object.getCallsign());
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper SSID")
+			void thenReturnSsid() {
+				assertEquals("15", object.getSsid());
+			}
+
+			@Test
+			@DisplayName("Then it should return as unused")
+			void thenReturnUsed() {
+				assertFalse(object.isUsed(), "Should not be used");
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper string")
+			void thenReturnProperString() {
+				assertEquals("W1AW-15", object.toString());
+			}
+
+			@Test
+			@DisplayName("Then it should return correct AX25 data")
+			void thenReturnAX25() {
+				final byte[] expected = {
+					(byte)('W' << 1),
+					(byte)('1' << 1),
+					(byte)('A' << 1),
+					(byte)('W' << 1),
+					(byte)(' ' << 1),
+					(byte)(' ' << 1),
+					(byte)(0*0x80 | 0x60 | (15 << 1)),
+				};
+				assertEquals(7, object.toAX25().length);
+				assertArrayEquals(expected, object.toAX25());
+			}
+		}
+		*/
+	}
+
+	/*
+	@Nested
+	@DisplayName("Given used, lower-case APRS digipeater")
+	class GivenUsedLowercaseDigipeater {
+		final String digipeater = "ab1cde*";
+
+		@Nested
+		@DisplayName("When instantiated as a class")
+		class WhenInstantiated {
+			Digipeater object;
+
+			@BeforeEach
+			void setUp() {
+				object = new Digipeater(digipeater);
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper callsign")
+			void thenReturnCallsign() {
+				assertEquals("AB1CDE", object.getCallsign());
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper SSID")
+			void thenReturnSsid() {
+				assertEquals("", object.getSsid());
+			}
+
+			@Test
+			@DisplayName("Then it should return as used")
+			void thenReturnUsed() {
+				assertTrue(object.isUsed(), "Should be used");
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper string")
+			void thenReturnProperString() {
+				assertEquals("AB1CDE*", object.toString());
+			}
+
+			@Test
+			@DisplayName("Then it should return correct AX25 data")
+			void thenReturnAX25() {
+				final byte[] expected = {
+					(byte)('A' << 1),
+					(byte)('B' << 1),
+					(byte)('1' << 1),
+					(byte)('C' << 1),
+					(byte)('D' << 1),
+					(byte)('E' << 1),
+					(byte)(1*0x80 | 0x60 | (0 << 1)),
+				};
+				assertEquals(7, object.toAX25().length);
+				assertArrayEquals(expected, object.toAX25());
+			}
+		}
+
+		@Nested
+		@DisplayName("When converted to bytes and back")
+		class WhenConverted {
+			Digipeater object;
+
+			@BeforeEach
+			void setUp() {
+				object = new Digipeater(
+					new Digipeater(digipeater).toAX25(), 0);
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper callsign")
+			void thenReturnCallsign() {
+				assertEquals("AB1CDE", object.getCallsign());
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper SSID")
+			void thenReturnSsid() {
+				assertEquals("", object.getSsid());
+			}
+
+			@Test
+			@DisplayName("Then it should return as used")
+			void thenReturnUsed() {
+				assertTrue(object.isUsed(), "Should be used");
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper string")
+			void thenReturnProperString() {
+				assertEquals("AB1CDE*", object.toString());
+			}
+
+			@Test
+			@DisplayName("Then it should return correct AX25 data")
+			void thenReturnAX25() {
+				final byte[] expected = {
+					(byte)('A' << 1),
+					(byte)('B' << 1),
+					(byte)('1' << 1),
+					(byte)('C' << 1),
+					(byte)('D' << 1),
+					(byte)('E' << 1),
+					(byte)(1*0x80 | 0x60 | (0 << 1)),
+				};
+				assertEquals(7, object.toAX25().length);
+				assertArrayEquals(expected, object.toAX25());
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName("Given an APRS digipeater")
+	class GivenDigipeater {
+		Digipeater object;
+
+		@BeforeEach
+		void setUp() {
+			object = new Digipeater("W1AW-1");
+		}
+		@Nested
+		@DisplayName("When changing ssid")
+		class WhenUsedChanged {
+			@BeforeEach
+			void setUp() {
+				object.setUsed(true);
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper callsign")
+			void thenReturnCallsign() {
+				assertEquals("W1AW", object.getCallsign());
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper SSID")
+			void thenReturnNewSsid() {
+				assertEquals("1", object.getSsid());
+			}
+
+			@Test
+			@DisplayName("Then it should return as used")
+			void thenReturnUsed() {
+				assertTrue(object.isUsed(), "Should be used");
+			}
+
+			@Test
+			@DisplayName("Then it should return the proper string")
+			void thenReturnProperString() {
+				assertEquals("W1AW-1*", object.toString());
+			}
+
+			@Test
+			@DisplayName("Then it should return correct AX25 data")
+			void thenReturnAX25() {
+				final byte[] expected = {
+					(byte)('W' << 1),
+					(byte)('1' << 1),
+					(byte)('A' << 1),
+					(byte)('W' << 1),
+					(byte)(' ' << 1),
+					(byte)(' ' << 1),
+					(byte)(1*0x80 | 0x60 | (1 << 1)),
+				};
+				assertEquals(7, object.toAX25().length);
+				assertArrayEquals(expected, object.toAX25());
+			}
+		}
+	}
+	*/
+}


### PR DESCRIPTION
In an effort to better learn about the library, I've written a number of unit tests for several classes. The one change to the code is normalizing the letter case on callsigns. I did later discover that some of it was done at a higher level, but still think it might be good to do in the callsign class itself. There is still some additional normalization that I think might be good to have (such as setting SSID to "0" to normalize as ""), but I didn't want to make too many changes to the code just yet without some discussion. It also seem to make a little more sense to just internally store SSID as an int to limit the invalid values it could contain.

One other area of testing that might require a discussion is the timestamps on position. I have one test disabled that is currently failing. It seems that it is returning the current time for a position report that has a fixed timestamp included. I wrote a comment that it might be local time, but it seems to be local current time, not even the report's timestamp at all. I'll have to investigate further.